### PR TITLE
Implement "has changed" API

### DIFF
--- a/brnkl_motion.api
+++ b/brnkl_motion.api
@@ -6,6 +6,9 @@ FUNCTION le_result_t getSuddenImpact(
   double z [N_CHANGE_BLOCKS] OUT,
   uint64 timestamps[N_CHANGE_BLOCKS] OUT
 );
+
+FUNCTION int8 hasSuddenImpact();
+
 FUNCTION le_result_t getCurrentAcceleration(
   double x OUT,
   double y OUT,

--- a/motionMonitor/motionMonitor.c
+++ b/motionMonitor/motionMonitor.c
@@ -82,6 +82,10 @@ le_result_t recordImpact(struct suddenImpacts_t* it,
   return LE_OK;
 }
 
+int8_t brnkl_motion_hasSuddenImpact() {
+  return impacts.nValues > 0;
+}
+
 le_result_t brnkl_motion_getSuddenImpact(double* xAcc,
                                          size_t* xSize,
                                          double* yAcc,

--- a/motionMonitor/motionMonitor.c
+++ b/motionMonitor/motionMonitor.c
@@ -5,7 +5,7 @@
 
 #define N_CHANGE_BLOCKS 200
 #define SAMPLE_PERIOD_MS 100
-#define DEFAULT_THRESHOLD_MS2 10
+#define DEFAULT_THRESHOLD_MS2 17
 
 void* impactMonitor(void*);
 


### PR DESCRIPTION
Please don't merge until #5 has been merged.

This involves 2 changes:

1. Factor the global scope into a struct. De-coupling the implementation from the global scope is always a good practice. Unfortunately Legato IPC routines still require this, but out implementation details should be de-coupled.

2. Allow the calling service to check if there are impacts before flushing them out.